### PR TITLE
fix/refact: PlayerCtrl.cs 버그 수정 및 PlayerMoveState.cs, PlayerJumpState…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "Adventurer-Brawl.sln"
+    "dotnet.defaultSolution": "Reverse-Of-Gaia.sln"
 }

--- a/Assets/2. Scripts/Ctrl/PlayerCtrl.cs
+++ b/Assets/2. Scripts/Ctrl/PlayerCtrl.cs
@@ -8,17 +8,12 @@ namespace Junyoung
     {
         public Rigidbody2D m_rigidbody;
 
-        private float m_walk_speed = 4.0f;
-        private float m_jump_power = 5.0f;
-        private int m_dir = 0;
         // PlayerMoveState에서 이동 속도와 방향을 일기만 할 수 있게 프로퍼티 작성
-        public float WalkSpeedP { get { return m_walk_speed; } private set { m_walk_speed = value; } }
-        public float JumpPowerP { get { return m_jump_power; } private set { m_jump_power = value; } }
-        public int DirP { get { return m_dir; } private set { m_dir = value; } }
+        public float MoveSpeed { get; private set; }
+        public float JumpPower { get; private set; }
 
         public Vector2 m_move_vec = Vector2.zero;
         public bool m_is_jump = false;
-
         public bool m_is_grunded = false;
 
         private IPlayerState m_stop_state, m_move_state, m_jump_state, m_dead_state, m_clear_state; // 각 상태들의 선언
@@ -33,7 +28,6 @@ namespace Junyoung
         {
             GameEventBus.Unsubscribe(GameEventType.PLAYING, GameManager.Instance.Playing);
         }
-
 
         private void Start()
         {
@@ -50,31 +44,29 @@ namespace Junyoung
             m_clear_state = gameObject.AddComponent<PlayerClearState>();
 
             m_player_state_context.Transition(m_stop_state);                // 플레이어의 초기 상태를 정지 상태로 설정
+
+            MoveSpeed = 4.0f;
+            JumpPower = 5.0f;
         }
 
-        public void PlayerMoveLeftBtnDown() // 좌측 이동 버튼 클릭으로 플레이어를 이동시킴
+        private void FixedUpdate()
         {
-            m_dir = -1;
-            m_player_state_context.Transition(m_move_state);
+            m_rigidbody.linearVelocity = new Vector2(m_move_vec.x * MoveSpeed, m_rigidbody.linearVelocity.y);
         }
 
-        public void PlayerMoveRightBtnDown()// 우측 이동 버튼 클릭으로 플레이어를 이동시킴
+        public void PlayerStop()
         {
-            m_dir = 1;
-            m_player_state_context.Transition(m_move_state);
-        }
-
-        public void PlayerMoveBtnUP() // 플레이어가 버튼에서 손을 땠을 때 움직임을 정지 시킴
-        {
-            m_dir = 0;
             m_player_state_context.Transition(m_stop_state);
+        }
+
+        public void PlayerMove()
+        {
+            m_player_state_context.Transition(m_move_state);
         }
 
         public void PlayerJump()
         {
-           
             m_player_state_context.Transition(m_jump_state);
-            
         }
 
         public void DeadPlayer()
@@ -85,6 +77,27 @@ namespace Junyoung
         public void ClearPlayer()
         {
             m_player_state_context.Transition(m_clear_state);
+        }
+
+        // 플레이어를 좌측 이동시키는 메소드
+        public void PlayerMoveLeftBtnDown() 
+        {
+            m_move_vec = Vector2.left;
+            PlayerMove();
+        }
+
+        // 플레이어를 우측 이동시키는 메소드
+        public void PlayerMoveRightBtnDown()
+        {
+            m_move_vec = Vector2.right;
+            PlayerMove();
+        }
+
+        // 플레이어가 이동 버튼에서 손을 떼었을 때 호출되는 메소드
+        public void PlayerMoveBtnUP()
+        {
+            m_move_vec = Vector2.zero;
+            PlayerStop();
         }
 
 

--- a/Assets/2. Scripts/PlayerState/PlayerJumpState.cs
+++ b/Assets/2. Scripts/PlayerState/PlayerJumpState.cs
@@ -5,21 +5,15 @@ namespace Junyoung
     public class PlayerJumpState : MonoBehaviour, IPlayerState
     {
         private PlayerCtrl m_player_ctrl;
-        private float m_jump_power;
-        private Rigidbody2D m_player_rigidbody;
 
         public void Handle(PlayerCtrl player_ctrl)
         {
             if (!m_player_ctrl)
             {
-                m_player_ctrl = player_ctrl;
-                m_jump_power = m_player_ctrl.JumpPowerP;
-                m_player_rigidbody = m_player_ctrl.m_rigidbody;                              
+                m_player_ctrl = player_ctrl;                            
             }
 
-            m_player_rigidbody.linearVelocity = Vector2.up * m_jump_power; // if문 안에 작성시 최초 한번만 동작함
+            m_player_ctrl.m_rigidbody.linearVelocity = Vector2.up * m_player_ctrl.JumpPower;
         }
-
-
     }
 }

--- a/Assets/2. Scripts/PlayerState/PlayerMoveState.cs
+++ b/Assets/2. Scripts/PlayerState/PlayerMoveState.cs
@@ -5,28 +5,13 @@ namespace Junyoung
     public class PlayerMoveState : MonoBehaviour, IPlayerState
     {
         private PlayerCtrl m_player_ctrl;
-        private int m_dir;
-        private float m_walk_speed;
-        private Rigidbody2D m_player_rigidbody;
 
         public void Handle(PlayerCtrl player_ctrl)
         {
-            if (!m_player_ctrl) // null일때 최초 한번만 작동해서 초기화 하는 역할
+            if (!m_player_ctrl) 
             {
                 m_player_ctrl = player_ctrl;
-                
-                m_walk_speed = m_player_ctrl.WalkSpeedP;
-                m_player_rigidbody = m_player_ctrl.m_rigidbody;
             }
-        }
-
-
-        void FixedUpdate() //프레임과 별도로 일정한 텀을 가지고 동작 -> 프레임간 시간 차이를 고려하지 않아도 됨
-        {
-            m_dir = m_player_ctrl.DirP;
-            // velocity는 질량과 관성등을 무시하고 입력된 속도로 움직여서, 미끄러짐 현상이 없음(정밀한 컨트롤 가능)
-            m_player_rigidbody.linearVelocity = new Vector2(m_dir * m_walk_speed, m_player_rigidbody.linearVelocity.y);  
-
         }
     }
 }


### PR DESCRIPTION
fix:
PlayerMoveState.cs의 NullRefException 해결
→ 각 State에서 Unity의 MonoBehaviour 컴포넌트 콜백 함수를 사용하면 NullRefException 발생
→ 플레이어 이동 로직 PlayerCtrl.cs로 이동

refact:
PlayerMoveState.cs, PlayerJumpState.cs의 변수
→ PlayerCtrl.cs의 프로퍼티 자체를 사용하도록 리팩터링

PlayerCtrl.cs 상태를 관리하는 래핑 메소드 구현
→ 각 버튼을 누를 때 StateContext에 직접 접근을 하는 것이 아닌 래핑 메소드를 통해 접근하도록 변경
 